### PR TITLE
Fix configure/_DEV files

### DIFF
--- a/configure/CONFIG_MODULE_DEV
+++ b/configure/CONFIG_MODULE_DEV
@@ -1,5 +1,5 @@
 #
-EPICS_MODULE_NAME:=ethercatmc
+EPICS_MODULE_NAME:=EthercatMC
 EPICS_MODULE_TAG:=master
 #
 E3_MODULE_VERSION:=working
@@ -20,7 +20,7 @@ MOTOR_DEP_VERSION:=6.9.5
 #
 E3_MODULE_NAME:=$(EPICS_MODULE_NAME)
 E3_MODULE_SRC_PATH:=$(EPICS_MODULE_NAME)-dev
-E3_MODULE_MAKEFILE:=$(EPICS_MODULE_NAME).Makefile
+E3_MODULE_MAKEFILE:=ethercatmc.Makefile
 
 #export DEV_GIT_URL:="https://where your git repo"
 E3_MODULE_DEV_GITURL:="https://bitbucket.org/europeanspallationsource/m-epics-EthercatMC"

--- a/configure/CONFIG_MODULE_DEV
+++ b/configure/CONFIG_MODULE_DEV
@@ -2,7 +2,13 @@
 EPICS_MODULE_NAME:=ethercatmc
 EPICS_MODULE_TAG:=master
 #
-E3_MODULE_VERSION:=develop
+E3_MODULE_VERSION:=working
+
+# DEPENDENT MODULE VERSION
+# Example,
+ASYN_DEP_VERSION:=4.33.0
+MOTOR_DEP_VERSION:=6.9.5
+
 
 # ONLY IF this module has the sequencer dependency. However,
 # in most case, we don't need to enable the following line,
@@ -17,7 +23,7 @@ E3_MODULE_SRC_PATH:=$(EPICS_MODULE_NAME)-dev
 E3_MODULE_MAKEFILE:=$(EPICS_MODULE_NAME).Makefile
 
 #export DEV_GIT_URL:="https://where your git repo"
-E3_MODULE_DEV_GITURL:="https://github.com/epics-modules/ethercatmc"
+E3_MODULE_DEV_GITURL:="https://bitbucket.org/europeanspallationsource/m-epics-EthercatMC"
 
 # The definitions shown below can also be placed in an untracked CONFIG_MODULE_DEV.local
 -include $(TOP)/configure/CONFIG_MODULE_DEV.local

--- a/configure/RELEASE_DEV
+++ b/configure/RELEASE_DEV
@@ -1,7 +1,7 @@
-EPICS_BASE=/testing/epics/base-3.15.5
+EPICS_BASE?=/epics/base-3.15.5
 
 E3_REQUIRE_NAME:=require
-E3_REQUIRE_VERSION:=0.0.0
+E3_REQUIRE_VERSION:=3.0.0
 
 # The definitions shown below can also be placed in an untracked RELEASE_DEV.local
 -include $(TOP)/../../RELEASE_DEV.local


### PR DESCRIPTION
Several fixes to allow to compile the module under e3
- Fix the git URL so that git clone is working
- Use require 3.0.0 instead of 0.0.0
- Add missing dependency to asyn,4.33.0 and motor,6.9.5